### PR TITLE
feat(staff-reenrollment): enable editable orgUnit selector for staff re-enrollment

### DIFF
--- a/src/components/assingFinalResult/assignFinalResult.tsx
+++ b/src/components/assingFinalResult/assignFinalResult.tsx
@@ -11,8 +11,11 @@ import { getContextualLabels } from "../../utils/common/getContextualLabels";
 
 export default function AsssignFinalResult({ selected }: { selected: any[] }) {
     const { dataStoreData } = useGetSelectedKeys()
-    const { "final-result": finalResult, trackedEntityType } = dataStoreData
-    const { dataElements } = useGetDataElements({ programStageId: finalResult?.programStage as unknown as string, type: "programStage" })
+    const { "final-result": finalResult, trackedEntityType } = dataStoreData || {}
+    const { dataElements } = useGetDataElements({
+        programStageId: finalResult?.programStage || '',
+        type: "programStage"
+    })
     const { urlParameters } = useUrlParams()
     const { school, sectionType } = urlParameters
     const [open, setOpen] = useState(false)
@@ -133,7 +136,7 @@ export default function AsssignFinalResult({ selected }: { selected: any[] }) {
                                             storyBook: false,
                                             name: labels.assignFormName,
                                             description: labels.assignFormDescription,
-                                            fields: dataElements
+                                            fields: dataElements || []
                                         }
                                     ]}
                                     storyBook={false}

--- a/src/components/performPromotion/performPromotion.tsx
+++ b/src/components/performPromotion/performPromotion.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
 import { format } from "date-fns";
 import { Form } from "react-final-form";
-import { NoticeBox, Button, IconAddCircle24 } from "@dhis2/ui";
+import { NoticeBox, Button, IconAddCircle24, CircularLoader, Center } from "@dhis2/ui";
 import useGetSelectedKeys from "../../hooks/config/useGetSelectedKeys";
 import { RulesEngine, useUrlParams } from "dhis2-semis-functions";
 import { usePromoteStudents } from "../../hooks/promote/usePromoteStudents";
 import { WithBorder, CustomForm, ModalComponent, WithPadding } from "dhis2-semis-components";
 import { Tooltip } from "@mui/material";
 import { getContextualLabels } from "../../utils/common/getContextualLabels";
+import { useAccessibleOrgUnits } from "../../hooks/common/useAccessibleOrgUnits";
 
 export default function PerformPromotion({ selected, setStats, openStats, formData = [] }: { openStats: (args: boolean) => void, setStats: any, selected: any[], formData: any[] }) {
     const { urlParameters } = useUrlParams()
@@ -15,16 +16,32 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
     const { program: programData, dataStoreData } = useGetSelectedKeys()
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
-    const [values, setValues] = useState<{ [key: string]: any }>({ orgUnit: school });
     const { promote } = usePromoteStudents({ selected, setOpen: openStats, setStats, setOpenPerform: setOpen, setLoading })
     const labels = getContextualLabels(sectionType as string)
+    const { orgUnits, loading: orgUnitsLoading, error: orgUnitsError, retry, hasOrgUnits } = useAccessibleOrgUnits()
 
-    const promotableStudents = selected.filter(estudante => {
-        const dvs = estudante.frEvent?.dataValues ?? [];
-        return dvs.length === 0 || dvs.some((dv: any) =>
+    const getInitialOrgUnit = () => {
+        if (sectionType !== 'staff' || !orgUnits.length) return school;
+        const currentSchoolExists = orgUnits.some(ou => ou.id === school);
+        return currentSchoolExists ? school : orgUnits[0]?.id;
+    };
+
+    const [selectedOrgUnit, setSelectedOrgUnit] = useState<string | undefined>(getInitialOrgUnit() || undefined);
+    const [values, setValues] = useState<{ [key: string]: any }>({ orgUnit: school || undefined });
+
+    const validStatusForReenrollment = sectionType === 'staff' ? 're-enrol' : 'promoted';
+
+    const nonPromotableEntities = selected.filter(entity => {
+        const dvs = entity.frEvent?.dataValues ?? [];
+
+        if (dvs.length === 0) return true;
+
+        const hasValidStatus = dvs.some((dv: any) =>
             dv.dataElement === dataStoreData["final-result"]?.status &&
-            dv.value?.toLowerCase() !== "promoted"
+            dv.value?.toLowerCase() === validStatusForReenrollment
         );
+
+        return !hasValidStatus;
     });
 
 
@@ -42,28 +59,66 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
         });
     }, [school])
 
+    useEffect(() => {
+        if (sectionType === 'staff' && orgUnits.length > 0) {
+            const initialOrgUnit = getInitialOrgUnit();
+            setSelectedOrgUnit(initialOrgUnit || undefined);
+        }
+    }, [orgUnits, sectionType])
+
 
     useEffect(() => {
         runRulesEngine()
     }, [values])
 
+    const modifyRegisteringSchoolField = (fields: any[]) => {
+        if (sectionType !== 'staff') return fields;
+
+        return fields.map(field => {
+            if (field.name === 'registeringSchool') {
+                return {
+                    ...field,
+                    disabled: false,
+                    valueType: "ORGANISATION_UNIT",
+                    options: orgUnits.map(ou => ({
+                        code: ou.id,
+                        label: ou.displayName,
+                        value: ou.id,
+                        name: ou.displayName
+                    })),
+                    searchable: true,
+                    required: true,
+                    assignedValue: selectedOrgUnit || school
+                };
+            }
+            return field;
+        });
+    }
+
 
     const handleChange = (e: { field: any; value: string; name: string }) => {
         const { name, value } = e;
+
+        if (name === 'registeringSchool' && sectionType === 'staff') {
+            setSelectedOrgUnit(value);
+        }
+
         setValues(prev => ({
             ...prev,
             [name]: value,
         }));
     };
 
-    const onClick = async (values: any) => await promote(values)
+    const onClick = async (values: any) => {
+        await promote(values);
+    }
 
     return (
         <>
             <Tooltip
-                title={promotableStudents?.length > 0 ? labels.noResultMessage : ""}
+                title={nonPromotableEntities?.length > 0 ? labels.noResultMessage : ""}
             >
-                <Button disabled={promotableStudents?.length > 0 || selected.length == 0} onClick={() => {
+                <Button disabled={nonPromotableEntities?.length > 0 || selected.length == 0} onClick={() => {
                     setOpen(true);
                 }} icon={<IconAddCircle24 />}
                 >
@@ -77,29 +132,56 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
                             No one will be able to access this program. Add some Organisation Units to the access list.
                         </NoticeBox>
                         <WithPadding />
-                        <WithBorder type="all" >
-                            <WithPadding>
-                                <CustomForm
-                                    Form={Form}
-                                    loading={loading}
-                                    initialValues={{ registeringSchool: schoolName, enrollment_date: format(new Date(), 'yyyy-MM-dd') }}
-                                    formFields={[
-                                        {
-                                            storyBook: false,
-                                            name: labels.formName,
-                                            description: labels.formDescription,
-                                            fields: updatedVariables || [],
-                                        }
-                                    ]}
-                                    storyBook={false}
-                                    withButtons={true}
-                                    onFormSubtmit={(values) => onClick(values)}
-                                    onCancel={() => setOpen(false)}
-                                    setFormValues={setValues}
-                                    onInputChange={handleChange}
-                                />
-                            </WithPadding>
-                        </WithBorder>
+
+                        {sectionType === 'staff' && orgUnitsLoading && (
+                            <Center>
+                                <CircularLoader small />
+                                <p>Loading organization units...</p>
+                            </Center>
+                        )}
+
+                        {sectionType === 'staff' && orgUnitsError && (
+                            <NoticeBox error title="Error loading organization units">
+                                Failed to load accessible organization units. {orgUnitsError.message}
+                                <WithPadding />
+                                <Button onClick={retry}>Retry</Button>
+                            </NoticeBox>
+                        )}
+
+                        {sectionType === 'staff' && !orgUnitsLoading && !orgUnitsError && !hasOrgUnits && (
+                            <NoticeBox error title="No accessible organization units">
+                                You do not have data-entry access to any organization units. Contact your administrator to grant you the necessary permissions.
+                            </NoticeBox>
+                        )}
+
+                        {((sectionType === 'staff' && hasOrgUnits && !orgUnitsLoading && !orgUnitsError) || sectionType !== 'staff') && (
+                            <WithBorder type="all" >
+                                <WithPadding>
+                                    <CustomForm
+                                        Form={Form}
+                                        loading={loading}
+                                        initialValues={{
+                                            registeringSchool: sectionType === 'staff' ? (selectedOrgUnit || school) : schoolName,
+                                            enrollment_date: format(new Date(), 'yyyy-MM-dd')
+                                        }}
+                                        formFields={[
+                                            {
+                                                storyBook: false,
+                                                name: labels.formName,
+                                                description: labels.formDescription,
+                                                fields: modifyRegisteringSchoolField(updatedVariables || []),
+                                            }
+                                        ]}
+                                        storyBook={false}
+                                        withButtons={true}
+                                        onFormSubtmit={(values) => onClick(values)}
+                                        onCancel={() => setOpen(false)}
+                                        setFormValues={setValues}
+                                        onInputChange={handleChange}
+                                    />
+                                </WithPadding>
+                            </WithBorder>
+                        )}
                     </WithPadding>}
                     open={open}
                     handleClose={() => setOpen(false)}

--- a/src/hooks/common/useAccessibleOrgUnits.ts
+++ b/src/hooks/common/useAccessibleOrgUnits.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { useDataQuery } from '@dhis2/app-runtime';
+
+interface OrgUnit {
+    id: string;
+    displayName: string;
+    path: string;
+}
+
+interface OrgUnitsResponse {
+    orgUnits: {
+        organisationUnits: OrgUnit[];
+    };
+}
+
+const ORG_UNITS_QUERY = {
+    orgUnits: {
+        resource: 'organisationUnits',
+        params: {
+            fields: 'id,displayName,path',
+            userDataViewFallback: true,
+            paging: false
+        }
+    }
+};
+
+export const useAccessibleOrgUnits = () => {
+    const [orgUnits, setOrgUnits] = useState<OrgUnit[]>([]);
+    const [error, setError] = useState<Error | null>(null);
+    const { loading, data, refetch } = useDataQuery<OrgUnitsResponse>(ORG_UNITS_QUERY, {
+        onError: (err) => setError(err)
+    });
+
+    useEffect(() => {
+        if (data?.orgUnits?.organisationUnits) {
+            setOrgUnits(data.orgUnits.organisationUnits);
+        }
+    }, [data]);
+
+    const retry = () => {
+        setError(null);
+        refetch();
+    };
+
+    return {
+        orgUnits,
+        loading,
+        error,
+        retry,
+        hasOrgUnits: orgUnits.length > 0
+    };
+};

--- a/src/hooks/promote/usePromoteStudents.ts
+++ b/src/hooks/promote/usePromoteStudents.ts
@@ -6,7 +6,7 @@ import { useGetUsedProgramStages, useSchoolCalendarKey } from "dhis2-semis-compo
 export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform, setLoading }: { setLoading: (args: boolean) => void, setOpenPerform: any, setStats: (args: any) => void, selected: any[], setOpen: (args: boolean) => void }) {
     const { getEvents } = useGetEvents()
     const { urlParameters } = useUrlParams();
-    const { school: orgUnit, sectionType } = urlParameters;
+    const { school, sectionType } = urlParameters;
     const { uploadValues } = useUploadEvents()
     const schoolCalendar = useSchoolCalendarKey()
     const { dataStoreData, program: programData } = useGetSelectedKeys()
@@ -18,6 +18,8 @@ export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform
         let registrationEvent: any = []
         let date = format(new Date(), 'yyyy-MM-dd')
         const socioEconomicPStage = dataStoreData["socio-economics"]?.programStage
+
+        const orgUnit = sectionType === 'staff' ? values.registeringSchool : school;
 
         const { registeringSchool, enrollment_date, ...registrationValues } = values
         for (const key in registrationValues) {
@@ -60,6 +62,10 @@ export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform
 
                 enrollments.push(
                     {
+                        trackedEntity: tei.trackedEntity,
+                        trackedEntityType: dataStoreData.trackedEntityType,
+                        orgUnit,
+                        attributes: tei.attributes || [],
                         enrollments: [
                             {
                                 occurredAt: date,
@@ -69,10 +75,7 @@ export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform
                                 status: "COMPLETED",
                                 events: events
                             }
-                        ],
-                        orgUnit,
-                        trackedEntityType: dataStoreData.trackedEntityType,
-                        trackedEntity: tei.trackedEntity
+                        ]
                     })
             } else setStats((prev: any) => ({ ...prev, conflicts: [...prev.conflicts, tei] }))
         }


### PR DESCRIPTION
- Created useAccessibleOrgUnits hook to fetch user's data-entry accessible orgUnits
- Modified registeringSchool field to be editable dropdown for staff (still read-only for students)
- Updated usePromoteStudents to use selected orgUnit from registeringSchool field
- Included retry functionality for failed orgUnit fetch