### PR TITLE
feat(final-result): allow multiple staff enrollments per academic year

### DIFF
--- a/src/hooks/promote/usePromoteStudents.ts
+++ b/src/hooks/promote/usePromoteStudents.ts
@@ -34,7 +34,9 @@ export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform
         }
 
         for (const tei of selected) {
-            const checkAlreadyPromoted = await getEvents({ program: tei.programId, fields: "*", trackedEntity: tei.trackedEntity, programStage: dataStoreData.registration.programStage, filter: [`${schoolCalendar?.academicYear}:in:${values?.[schoolCalendar?.academicYear]}`] })
+            const checkAlreadyPromoted = sectionType === 'staff'
+                ? []
+                : await getEvents({ program: tei.programId, fields: "*", trackedEntity: tei.trackedEntity, programStage: dataStoreData.registration.programStage, filter: [`${schoolCalendar?.academicYear}:in:${values?.[schoolCalendar?.academicYear]}`] })
 
             if (checkAlreadyPromoted?.length === 0) {
                 let events = []


### PR DESCRIPTION
Skip uniqueness check for staff re-enrollment to enable creating multiple enrollments in the same academic year. Students retain the existing constraint of one enrollment per academic year.