### PR TITLE
feat(final-result): Allow student/staff promotion based on DataStore mapped status.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,15 +9,15 @@ const MyApp = () => {
     const { baseUrl } = useConfig()
 
     return (
-        <AppWrapper
-            baseUrl={baseUrl}
-            dataStoreKey="dataStore/semis/values"
-            schoolCalendarKey='dataStore/semis/schoolCalendar'
-        >
-            <HashRouter>
-                <Router />
-            </HashRouter >
-        </AppWrapper>
+        // <AppWrapper
+        //     baseUrl={baseUrl}
+        //     dataStoreKey="dataStore/semis/values"
+        //     schoolCalendarKey='dataStore/semis/schoolCalendar'
+        // >
+        //     <HashRouter>
+        <Router />
+        //     </HashRouter >
+        // </AppWrapper>
     )
 }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,15 +9,15 @@ const MyApp = () => {
     const { baseUrl } = useConfig()
 
     return (
-        // <AppWrapper
-        //     baseUrl={baseUrl}
-        //     dataStoreKey="dataStore/semis/values"
-        //     schoolCalendarKey='dataStore/semis/schoolCalendar'
-        // >
-        //     <HashRouter>
+        <AppWrapper
+            baseUrl={baseUrl}
+            dataStoreKey="dataStore/semis/values"
+            schoolCalendarKey='dataStore/semis/schoolCalendar'
+        >
+            <HashRouter>
                 <Router />
-        //     </HashRouter >
-        // </AppWrapper>
+            </HashRouter >
+        </AppWrapper>
     )
 }
 

--- a/src/components/performPromotion/performPromotion.tsx
+++ b/src/components/performPromotion/performPromotion.tsx
@@ -29,7 +29,10 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
     const [selectedOrgUnit, setSelectedOrgUnit] = useState<string | undefined>(getInitialOrgUnit() || undefined);
     const [values, setValues] = useState<{ [key: string]: any }>({ orgUnit: school || undefined });
 
-    const validStatusForReenrollment = sectionType === 'staff' ? 're-enrol' : 'promoted';
+    const finalResultConfig = dataStoreData?.["final-result"];
+    const statusDataElementId = finalResultConfig?.status;
+    const validStatusValues = (finalResultConfig as any)?.validStatusValue || [];
+    const hasValidConfiguration = validStatusValues.length > 0;
 
     const nonPromotableEntities = selected.filter(entity => {
         const dvs = entity.frEvent?.dataValues ?? [];
@@ -37,8 +40,8 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
         if (dvs.length === 0) return true;
 
         const hasValidStatus = dvs.some((dv: any) =>
-            dv.dataElement === dataStoreData["final-result"]?.status &&
-            dv.value?.toLowerCase() === validStatusForReenrollment
+            dv.dataElement === statusDataElementId &&
+            validStatusValues.map((v: string) => v.toLowerCase()).includes(dv.value?.toLowerCase())
         );
 
         return !hasValidStatus;
@@ -113,12 +116,22 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
         await promote(values);
     }
 
+    const getTooltipMessage = () => {
+        if (!hasValidConfiguration) {
+            return `Configuration error: validStatusValue not set in DataStore for ${sectionType}`;
+        }
+        if (nonPromotableEntities?.length > 0) {
+            return labels.noResultMessage;
+        }
+        return "";
+    };
+
     return (
         <>
             <Tooltip
-                title={nonPromotableEntities?.length > 0 ? labels.noResultMessage : ""}
+                title={getTooltipMessage()}
             >
-                <Button disabled={nonPromotableEntities?.length > 0 || selected.length == 0} onClick={() => {
+                <Button disabled={!hasValidConfiguration || nonPromotableEntities?.length > 0 || selected.length == 0} onClick={() => {
                     setOpen(true);
                 }} icon={<IconAddCircle24 />}
                 >

--- a/src/types/dataStore/DataStoreConfig.ts
+++ b/src/types/dataStore/DataStoreConfig.ts
@@ -51,6 +51,7 @@ interface finalResult {
     lastUpdate?: string
     programStage: string
     status: string
+    validStatusValue?: string[]
 }
 
 interface dataStoreRecord {


### PR DESCRIPTION
Add validStatusValue field as an array of strings in the final-result DataStore configuration to support multiple promotable statuses without hardcoding values.
- Add validStatusValue as optional string array in finalResult interface
- Update performPromotion validation to check against configured status values
- Add error handling when validStatusValue is missing or empty
- Disable promotion button with helpful tooltip when configuration is invalid
- Remove all hardcoded status values (re-enrol, promoted, etc.)

DataStore configuration now requires:
{
  final-result: { status: dataElementId, validStatusValue: [ReEnrol, Promoted] } }