### PR TITLE
build: update tsconfig for monorepo path mappings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,19 +7,20 @@ import { HashRouter } from 'react-router-dom'
 import { D2I18n } from 'dhis2-semis-types'
 import translator from '../locales/index';
 
-const MyApp = ({ i18n }: { i18n: D2I18n }) => {
-    const { baseUrl } = useConfig()
+const MyApp = ({ i18n, baseUrl }: { i18n: D2I18n; baseUrl?: string }) => {
+    const { baseUrl: localBaseUrl } = useConfig()
     const translation: any = i18n ? i18n : translator
+    const useBaseUrl = baseUrl || localBaseUrl
 
     return (
         // <AppWrapper
-        //     baseUrl={baseUrl}
+        //     baseUrl={useBaseUrl}
         //     i18n={translation}
         //     dataStoreKey="dataStore/semis/values"
         //     schoolCalendarKey='dataStore/semis/schoolCalendar'
         // >
         //     <HashRouter>
-                <Router i18n={translation as unknown as any} />
+                <Router i18n={translation as unknown as any} baseUrl={useBaseUrl} />
         //     </HashRouter >
         // </AppWrapper>
     )

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -4,11 +4,11 @@ import { Routes, Route } from 'react-router-dom';
 import WithHeaderBarLayout from '../../layout/WithHeaderBarLayout';
 import { D2I18n } from 'dhis2-semis-types';
 
-export default function Router({ i18n }: { i18n: D2I18n }) {
+export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: string }) {
     return (
         <Routes>
             <Route path='/'
-                element={<WithHeaderBarLayout />}
+                element={<WithHeaderBarLayout baseUrl={baseUrl} />}
             >
                 <Route key={'final-result'} path={'/'} element={<FinalResult i18n={i18n} />} />
             </Route>

--- a/src/layout/WithHeaderBarLayout.tsx
+++ b/src/layout/WithHeaderBarLayout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from "react-router-dom"
-import { useConfig } from "@dhis2/app-runtime"
 import useGetSelectedKeys from "../hooks/config/useGetSelectedKeys"
 import { HeaderBarLayout, SemisHeader, useSchoolCalendarKey } from "dhis2-semis-components"
 
-const WithHeaderBarLayout = () => {
-    const { baseUrl } = useConfig()
+const WithHeaderBarLayout = ({ baseUrl }: { baseUrl: string }) => {
     const schoolCalendar = useSchoolCalendarKey()
     const { program, dataStoreData } = useGetSelectedKeys()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path mappings for internal libraries to support monorepo structure. This enables proper TypeScript resolution for 'dhis2-semis-components', 'dhis2-semis-functions', and 'dhis2-semis-types' packages.