### PR TITLE
fix: correct parameter name from trackedEntity to trackedEntities

### DIFF
--- a/src/components/assingFinalResult/assignFinalResult.tsx
+++ b/src/components/assingFinalResult/assignFinalResult.tsx
@@ -34,7 +34,7 @@ export default function AsssignFinalResult({ selected, i18n }: { selected: any[]
         for (const tei of selected) {
             const frEvents = await getEvents({
                 program: tei?.programId, fields: "*",
-                trackedEntity: tei?.trackedEntity,
+                trackedEntities: tei?.trackedEntity,
                 programStage: finalResult?.programStage
             })
             const selectedEnrollmentFrEvent = frEvents.find((x: any) => x.enrollment === tei?.enrollmentId)

--- a/src/hooks/promote/usePromoteStudents.ts
+++ b/src/hooks/promote/usePromoteStudents.ts
@@ -36,13 +36,13 @@ export function usePromoteStudents({ selected, setOpen, setStats, setOpenPerform
         for (const tei of selected) {
             const checkAlreadyPromoted = sectionType === 'staff'
                 ? []
-                : await getEvents({ program: tei.programId, fields: "*", trackedEntity: tei.trackedEntity, programStage: dataStoreData.registration.programStage, filter: [`${schoolCalendar?.academicYear}:in:${values?.[schoolCalendar?.academicYear]}`] })
+                : await getEvents({ program: tei.programId, fields: "*", trackedEntities: tei.trackedEntity, programStage: dataStoreData.registration.programStage, filter: [`${schoolCalendar?.academicYear}:in:${values?.[schoolCalendar?.academicYear]}`] })
 
             if (checkAlreadyPromoted?.length === 0) {
                 let events = []
                 let socioEconomicDataValues: any = []
 
-                const socioEconomicEvent = await getEvents({ program: tei.programId, fields: "*", trackedEntity: tei.trackedEntity, programStage: socioEconomicPStage })
+                const socioEconomicEvent = await getEvents({ program: tei.programId, fields: "*", trackedEntities: tei.trackedEntity, programStage: socioEconomicPStage })
                 const event = socioEconomicEvent?.find((x: any) => x.enrollment === tei.enrollmentId)
 
                 if (event) {


### PR DESCRIPTION
The API expects the parameter name to be "trackedEntities" (plural) instead of "trackedEntity" (singular). This change fixes the API calls in both the assignFinalResult component and usePromoteStudents hook to use the correct parameter name.