### PR TITLE
feat: propagate baseUrl prop to FinalResult component

### DIFF
--- a/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
+++ b/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
@@ -8,17 +8,15 @@ import { DataExporter, DataImporter, CustomDropdown as DropdownButton, useSchool
 import AsssignFinalResult from '../assingFinalResult/assignFinalResult';
 import PerformPromotion from '../performPromotion/performPromotion';
 import ShowStats from '../stats/showStats';
-import { useConfig } from '@dhis2/app-runtime';
 import { Tooltip } from '@mui/material';
 import useGetSelectedKeys from '../../hooks/config/useGetSelectedKeys';
 import { staticForm } from "../../constants/searchEnrollmentForm";
 import { getContextualLabels } from '../../utils/common/getContextualLabels';
 import { useSetRecoilState } from 'recoil';
 
-function EnrollmentActionsButtons({ programData, selectedDataStoreKey, selected, i18n }: { selected: any, programData: ProgramConfig, selectedDataStoreKey: selectedDataStoreKey, i18n: any }) {
+function EnrollmentActionsButtons({ programData, selectedDataStoreKey, selected, i18n, baseUrl }: { selected: any, programData: ProgramConfig, selectedDataStoreKey: selectedDataStoreKey, i18n: any, baseUrl: string }) {
     const { urlParameters } = useUrlParams();
     const schoolCalendar = useSchoolCalendarKey()
-    const { baseUrl } = useConfig()
     const { school: orgUnit, class: section, grade, academicYear, sectionType } = urlParameters;
     const { sectionName } = useGetSectionTypeLabel();
     const { dataStoreData } = useGetSelectedKeys()

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -10,7 +10,7 @@ export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: strin
             <Route path='/'
                 element={<WithHeaderBarLayout baseUrl={baseUrl} />}
             >
-                <Route key={'final-result'} path={'/'} element={<FinalResult i18n={i18n} />} />
+                <Route key={'final-result'} path={'/'} element={<FinalResult i18n={i18n} baseUrl={baseUrl} />} />
             </Route>
         </Routes>
     );

--- a/src/pages/final-result/final-result.tsx
+++ b/src/pages/final-result/final-result.tsx
@@ -9,7 +9,7 @@ import { useFinalResultConst } from '../../hooks/common/finalResultConst';
 import EnrollmentActionsButtons from "../../components/enrollmentButtons/EnrollmentActionsButtons";
 import { useCheckFilters, useHeader, useTableData, useUrlParams, useViewPortWidth } from "dhis2-semis-functions";
 
-export default function FinalResult({ i18n }: { i18n: D2I18n }) {
+export default function FinalResult({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: string }) {
   const { viewPortWidth } = useViewPortWidth();
   const { urlParameters } = useUrlParams();
   const [selected, setSelected] = useState([])
@@ -105,6 +105,7 @@ export default function FinalResult({ i18n }: { i18n: D2I18n }) {
                   selected={selected}
                   selectedDataStoreKey={dataStoreData}
                   programData={programData as unknown as ProgramConfig}
+                  baseUrl={baseUrl}
                 />
               }
               setFilterState={setFilterState}


### PR DESCRIPTION
Pass baseUrl from Router down to FinalResult and EnrollmentActionsButtons to replace the previous usage of useConfig hook. This ensures the baseUrl is available where needed without relying on runtime configuration context.