### PR TITLE
fix(final-result):

### DIFF
--- a/src/components/performPromotion/performPromotion.tsx
+++ b/src/components/performPromotion/performPromotion.tsx
@@ -31,20 +31,24 @@ export default function PerformPromotion({ selected, setStats, openStats, formDa
 
     const finalResultConfig = dataStoreData?.["final-result"];
     const statusDataElementId = finalResultConfig?.status;
-    const validStatusValues = (finalResultConfig as any)?.dropoutStatusValues || [];
-    const hasValidConfiguration = validStatusValues.length > 0;
+    const validStatusValues = (finalResultConfig as any)?.validStatusValue?.length
+        ? (finalResultConfig as any).validStatusValue
+        : (finalResultConfig as any)?.dropoutStatusValues || [];
+    const normalizeStatusValue = (value: any) => String(value ?? "").trim().toLowerCase();
+    const normalizedValidStatusValues = validStatusValues
+        .map((value: any) => normalizeStatusValue(value))
+        .filter(Boolean);
+    const hasValidConfiguration = Boolean(statusDataElementId) && normalizedValidStatusValues.length > 0;
 
     const nonPromotableEntities = selected.filter(entity => {
         const dvs = entity.frEvent?.dataValues ?? [];
 
-        if (dvs.length === 0) return true;
+        if (dvs.length === 0 || !statusDataElementId) return true;
 
-        const hasValidStatus = dvs.some((dv: any) =>
-            dv.dataElement === statusDataElementId &&
-            !validStatusValues.map((v: string) => v.toLowerCase()).includes(dv.value?.toLowerCase())
-        );
+        const statusDataValue = dvs.find((dv: any) => dv.dataElement === statusDataElementId);
+        if (!statusDataValue) return true;
 
-        return !hasValidStatus;
+        return !normalizedValidStatusValues.includes(normalizeStatusValue(statusDataValue.value));
     });
 
 


### PR DESCRIPTION
- enable staff re-enroll action for configured promotable statuses. 
- Fix inverted re-enrollment eligibility logic in PerformPromotion so selected staff/students are treated as promotable when their final-result status is included in the configured allowed status list. 
- Use final-result.validStatusValue as the primary source of promotable statuses and fall back to dropoutStatusValues for backward compatibility with older DataStore configurations.
-  Normalize status comparisons (trim + lowercase) to avoid case/whitespace mismatches between stored event values and configured status values. 
- Tested on DHIS2 versions 2.39 and 2.42